### PR TITLE
Change free service host from AWS to DO

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ avn user login
 and then : 
 
 ```
-avn service create postgres-rgb  -t pg --plan  free-1-5gb --cloud aws-us-east-1 
+avn service create postgres-rgb  -t pg --plan  free-1-5gb --cloud do-ams
 ```
 
 


### PR DESCRIPTION
Aiven free services are now hosted on DIgitalOcean instead of AWS.

This PR changes the command line given (in the README) for creating a PostgreSQL service to use `do-ams` instead of AWS

I can confirm that `avn service create postgres-rgb  -t pg --plan  free-1-5gb --cloud do-ams` worked for me when I just tried it 😄 